### PR TITLE
fix: PDF upload rejected by content type check

### DIFF
--- a/app/lib/files.server.ts
+++ b/app/lib/files.server.ts
@@ -96,7 +96,13 @@ export async function parseFileFormData({
   try {
     const uploadHandler = unstable_composeUploadHandlers(
       async ({contentType, data, filename}) => {
-        if (!contentType?.includes('image') || !filename) {
+        const allowedContentTypes = [
+          'image/png',
+          'image/svg+xml',
+          'application/pdf',
+        ];
+
+        if (!contentType || !allowedContentTypes.includes(contentType) || !filename) {
           return undefined;
         }
 


### PR DESCRIPTION
The upload handler only allowed content types containing "image", which excluded application/pdf. Use an explicit allowlist instead.